### PR TITLE
PostInstall script for generating config before first application run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/index.js
+++ b/index.js
@@ -337,11 +337,27 @@ function get_config_path() {
         }
         install_path = homedir + "/.terminal-discord";
       }
-
-      fs.writeFileSync(
-        install_path + "/config.json",
-        '{\n"token": "",\n"max_name_length": null,\n"allign": false,\n"separator": ":",\n"history_length": null,\n"default_guild": null,\n"default_channel": null,\n"mention_color": "#A52D00",\n"default_color": "#FFFFFF",\n"prompt": ">",\n"show_date": true,\n"show_time": true,\n"use_nickname": true,\n"select_count": 8,\n"color_support": true,\n"show_embeds": true,\n"repeat_name": true,\n"right_bound": false\n}'
-      );
+      let config = {
+        max_name_length: null,
+        allign: false,
+        separator: ":",
+        history_length: null,
+        default_guild: null,
+        default_channel: null,
+        mention_color: "#A52D00",
+        default_color: "#FFFFFF",
+        prompt: ">",
+        show_date: true,
+        show_time: true,
+        use_nickname: true,
+        token: "",
+        select_count: 8,
+        color_support: true,
+        show_embeds: true,
+        repeat_name: true,
+        right_bound: false
+      };
+      fs.writeFileSync(install_path + "/config.json", JSON.stringify(config, undefined, 4));
       console_out("Created a config file in " + install_path);
       return install_path + "config.json";
     } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "terminal-discord",
-  "version": "1.5.2",
+  "version": "1.5.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   },
   "devDependencies": {},
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "postinstall": "node ./post-install.js"
   },
   "repository": {
     "type": "git",
@@ -20,7 +21,6 @@
   "bin": {
     "terminal-discord": "index.js"
   },
-  "postinstall": "node ./post-install.js",
   "license": "ISC",
   "bugs": {
     "url": "https://github.com/xynxynxyn/terminal-discord/issues"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "bin": {
     "terminal-discord": "index.js"
   },
+  "postinstall": "node ./post-install.js",
   "license": "ISC",
   "bugs": {
     "url": "https://github.com/xynxynxyn/terminal-discord/issues"

--- a/post-install.js
+++ b/post-install.js
@@ -10,8 +10,8 @@ function generate_config() {
         configDirPath = homedir + "/.terminal-discord";
     }
     let configFilePath = configDirPath + "/config.json";
-    console.log(fs.existsSync(configDirPath))
-    console.log(fs.existsSync(configFilePath))
+    console.log("Does config directory exist: " + fs.existsSync(configDirPath))
+    console.log("Does config file exist: " + fs.existsSync(configFilePath))
     if (!fs.existsSync(configDirPath)) {
         console.log("\nGenerating config directory at " + configDirPath);
         fs.mkdirSync(configDirPath);

--- a/post-install.js
+++ b/post-install.js
@@ -1,0 +1,28 @@
+const fs = require("fs");
+const configObject = require("./config.json")
+function generate_config() {
+    let homedir = process.env.HOME;
+    let configDirPath;
+    if (fs.existsSync(homedir + "/.config")) {
+        configDirPath = homedir + "/.config/terminal-discord";
+    } 
+    else {
+        configDirPath = homedir + "/.terminal-discord";
+    }
+    let configFilePath = configDirPath + "/config.json";
+    console.log(fs.existsSync(configDirPath))
+    console.log(fs.existsSync(configFilePath))
+    if (!fs.existsSync(configDirPath)) {
+        console.log("\nGenerating config directory at " + configDirPath);
+        fs.mkdirSync(configDirPath);
+    }
+    if(!fs.existsSync(configFilePath)) {
+        console.log("\nGenerating default configuration file at " + configFilePath + " inside config directory.\n");
+        fs.writeFileSync(configFilePath, JSON.stringify(configObject, undefined, 4));
+    }
+    else {
+        console.log("terminal-discord config already exists.")
+    }
+}
+
+generate_config()


### PR DESCRIPTION
Creates a config file at ~/.config/terminal-discord after installation of package from npm.

Also made a file write method change in get_config_path() to use JSON.stringify instead of writing it as a string.