### PR TITLE
added: /help

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,20 +126,22 @@ Enter a command while in a channel using /.
 
 **d**, **delete**: deletes the last sent message
 
-**e**, **edit**: replace the content of your last sent message with the string after /e. Pressing tab after "/edit " fills in the previous message
+**e**, **edit**: replaces the content of your last sent message with the string after /e. Pressing tab after "/edit " fills in the previous message
 
-**c**, **channel**: select a different channel within the same guild
+**c**, **channel**: selects a different channel within the same guild
 
-**m**, **menu**: open the channel selection menu to switch to a different channel
+**m**, **menu**: opens the channel selection menu to switch to a different channel
 
-**o**, **online**: show a list of currently online users
+**o**, **online**: shows a list of currently online users
 
-**g**, **gr**, **group**: open group chat selection menu to switch to a different channel
+**g**, **gr**, **group**: opens group chat selection menu to switch to a different channel
 
-**dm**, **pm**: open dm chat selection menu to switch to a different channel
+**dm**, **pm**: opens dm chat selection menu to switch to a different channel
 
-**i**, **info**: display basic information about the channel including indices
+**i**, **info**: displays basic information about the channel including indices
 
-**b**, **block**: toggle display of blocked messages
+**b**, **block**: toggles display of blocked messages
+
+**h**, **help**: shows help message
 
 Note that edit and delete only work on messages sent in the current session. If you haven't sent a message in the current session the command will do nothing.

--- a/index.js
+++ b/index.js
@@ -591,6 +591,49 @@ function channel_info() {
   );
 }
 
+function help_info() {
+  const color = (text) => {
+    if (!config["color_support"]) {
+      return text;
+    }
+
+    return chalk.hex(config["default_color"])(text);
+  }
+
+  console_out(
+    "Enter a command while in a channel using " + color("/") + ".\n" +
+    color("q") + " or " + color("quit") +
+    ": exits the client\n" +
+    color("u") + ", " + color("update") + ", " + color("r") + ", " +
+    color("refresh") +
+    ": refresh manually\n" +
+    color("nick") +
+    ": changes your nickname\n" +
+    color("d") + ", " + color("delete") +
+    ": deletes the last sent message\n" +
+    color("e") + ", " + color("edit") +
+    ": replaces the content of your last sent message with the string after\n " +
+    color("/e") + ". Pressing tab after " + color("/edit") +
+    " fills in the previous message\n" +
+    color("c") + ", " + color("channel") +
+    ": selects a different channel within the same guild\n" +
+    color("m") + ", " + color("menu") +
+    ": opens the channel selection menu to switch to a different channel\n" +
+    color("o") + ", " + color("online") +
+    ": shows a list of currently online users\n" +
+    color("g") + ", " + color("gr") + ", " + color("group") +
+    ": opens group chat selection menu to switch to a different channel\n" +
+    color("dm") + ", " + color("pm") +
+    ": opens dm chat selection menu to switch to a different channel\n" +
+    color("i") + ", " + color("info") +
+    ": displays basic information about the channel including indices\n" +
+    color("b") + ", " + color("block") +
+    ": toggles display of blocked messages\n" +
+    color("h") + ", " + color("help") +
+    ": shows help message\n"
+  );
+}
+
 // parse and update prompt
 function update_prompt() {
   let raw_prompt = config["prompt"];
@@ -792,6 +835,15 @@ function command(cmd, arg) {
     case "b":
     case "block":
       hide_blocked = !hide_blocked;
+      clear_screen();
+      update();
+      break;
+    case "h":
+    case "help":
+      help_info();
+      rl.pause()
+      rl_sync.keyInPause(" ");
+      rl.resume();
       clear_screen();
       update();
       break;


### PR DESCRIPTION
Also made spelling in README more consistent by using simple present tense everywhere in command descriptions, except of `/refresh`.